### PR TITLE
Update pnpm to 11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "book-launch-notifier",
 	"version": "0.0.0",
 	"private": true,
-	"packageManager": "pnpm@11.11.0",
+	"packageManager": "pnpm@11.13.0",
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",


### PR DESCRIPTION
## Summary

- update `package.json#packageManager` from `pnpm@11.11.0` to the exact `pnpm@11.13.0` release
- keep `package.json` as the single pnpm version source; workflows remain unchanged
- retain the existing lockfile because pnpm 11.13.0 re-resolution produced no diff

## Root cause

The pnpm 11.12.0 update failed in `pnpm/action-setup@v6.0.9` before repository commands ran. Its self-installer attempted to switch from pnpm 11.7.0 to 11.12.0 and exited with `Cannot use 'in' operator to search for 'integrity' in undefined`.

pnpm 11.13.0 contains the corrected published package structure for this setup path.

## Impact

CI can install the repository-managed pnpm version without weakening or bypassing any checks.

## Validation

- `CI=true pnpm install --lockfile-only`
- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm run lint`
- `CI=true pnpm run fmt:check`
- `CI=true pnpm exec tsc --noEmit`
- `CI=true pnpm vitest run`
- `CI=true pnpm run cf-typegen` with no generated-file diff
- `CI=true pnpm exec wrangler deploy --dry-run`
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format github .`
